### PR TITLE
fix: prevent command injection by replacing exec with execFile

### DIFF
--- a/src/utils/cross-platform.ts
+++ b/src/utils/cross-platform.ts
@@ -1,9 +1,9 @@
-import { exec as execCallback } from 'child_process';
+import { execFile as execFileCallback } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs/promises';
 import path from 'path';
 
-const exec = promisify(execCallback);
+const execFile = promisify(execFileCallback);
 
 export function generateTempDirName(): string {
   const timestamp = Date.now();
@@ -70,13 +70,13 @@ export async function moveFileOrDirectory(
 }
 
 export async function executeGitCommand(
-  command: string,
+  args: string[],
   options: { cwd: string; timeout?: number } = { cwd: process.cwd() },
 ): Promise<string> {
   const { cwd, timeout = 30000 } = options;
 
   try {
-    const { stdout, stderr } = await exec(command, {
+    const { stdout, stderr } = await execFile('git', args, {
       cwd,
       timeout,
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0' }, // Disable interactive prompts

--- a/src/utils/download-strategies.ts
+++ b/src/utils/download-strategies.ts
@@ -23,13 +23,13 @@ export async function downloadFullRepository(
 
   try {
     // Initialize git repository
-    await executeGitCommand('git init --quiet', {
+    await executeGitCommand(['init', '--quiet'], {
       cwd: projectPath,
     });
 
     // Add remote origin
     await executeGitCommand(
-      `git remote add origin https://github.com/${data.owner}/${data.project}`,
+      ['remote', 'add', 'origin', `https://github.com/${data.owner}/${data.project}`],
       { cwd: projectPath },
     );
 
@@ -42,7 +42,7 @@ export async function downloadFullRepository(
 
     for (const branch of uniqueBranches) {
       try {
-        await executeGitCommand(`git pull origin ${branch} --depth 1 --quiet`, {
+        await executeGitCommand(['pull', 'origin', branch, '--depth', '1', '--quiet'], {
           cwd: projectPath,
         });
         success = true;
@@ -75,18 +75,18 @@ export async function downloadPartialRepository(
 ): Promise<void> {
   try {
     // Initialize git repository in temp directory
-    await executeGitCommand('git init --quiet', {
+    await executeGitCommand(['init', '--quiet'], {
       cwd: tempDir,
     });
 
     // Add remote origin
     await executeGitCommand(
-      `git remote add origin https://github.com/${data.owner}/${data.project}`,
+      ['remote', 'add', 'origin', `https://github.com/${data.owner}/${data.project}`],
       { cwd: tempDir },
     );
 
     // Enable sparse checkout
-    await executeGitCommand('git config core.sparseCheckout true', {
+    await executeGitCommand(['config', 'core.sparseCheckout', 'true'], {
       cwd: tempDir,
     });
 
@@ -102,7 +102,7 @@ export async function downloadPartialRepository(
 
     // Pull the specific branch with sparse checkout
     await executeGitCommand(
-      `git pull origin ${data.branch} --depth 1 --quiet`,
+      ['pull', 'origin', data.branch, '--depth', '1', '--quiet'],
       { cwd: tempDir },
     );
 
@@ -256,7 +256,7 @@ function handleDownloadStream(
 
 export async function validateGitAvailability(): Promise<void> {
   try {
-    const output = await executeGitCommand('git --version', {
+    const output = await executeGitCommand(['--version'], {
       cwd: process.cwd(),
     });
     console.log(`Using ${output.trim()}`);


### PR DESCRIPTION
## Description

Fixed a critical command injection vulnerability in the executeGitCommand function.

## Root Cause

The current implementation uses child_process.exec, which spawns a shell and executes the command string. Maliciously crafted GitHub URLs containing shell metacharacters (e.g., ;, |, &) can escape the intended git command and execute arbitrary code on the host system.
## Fix

+ Replaced child_process.exec with child_process.execFile in cross-platform.ts.
+ Updated executeGitCommand to accept an array of arguments instead of a raw string, ensuring that user-provided data is treated as arguments only and not interpreted by the shell.
+ Refactored download-strategies.ts to pass parameters as arrays.

POC:
```javascript
const goGitIt = require('go-git-it');
const path = require('path');
const fs = require('fs');

async function triggerInjection() {
  // this will create a file name "PWNED" in /tmp folder
  const maliciousUrl = "https://github.com/owner/repo;echo$IFS'dG91Y2ggL3RtcC9QV05FRA=='|base64$IFS'-d'|sh;";

  const outputDir = path.join(__dirname, 'test-output');

  try {
    await goGitIt.default(maliciousUrl, outputDir);
  } catch (error) {}
}

triggerInjection();
```
Wish you a good day. Ciallo～(∠・ω< )⌒★